### PR TITLE
removed the [Not Mapped] attributes from properties

### DIFF
--- a/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigChannel.cs
+++ b/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigChannel.cs
@@ -17,7 +17,7 @@ namespace Discord.Addons.SimplePermissions
         public int Id { get; set; }
 
         /// <summary> </summary>
-        [NotMapped]
+        ///[NotMapped]
         public ulong ChannelId
         {
             get => unchecked((ulong)_cid);

--- a/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigGuild.cs
+++ b/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigGuild.cs
@@ -19,7 +19,7 @@ namespace Discord.Addons.SimplePermissions
         public int Id { get; set; }
 
         /// <summary> </summary>
-        [NotMapped]
+        //[NotMapped]
         public ulong GuildId
         {
             get => unchecked((ulong)_gid);
@@ -27,7 +27,7 @@ namespace Discord.Addons.SimplePermissions
         }
 
         /// <summary> </summary>
-        [NotMapped]
+        ///[NotMapped]
         public ulong ModRole
         {
             get => unchecked((ulong)_mid);
@@ -35,7 +35,7 @@ namespace Discord.Addons.SimplePermissions
         }
 
         /// <summary> </summary>
-        [NotMapped]
+        ///[NotMapped]
         public ulong AdminRole
         {
             get => unchecked((ulong)_aid);

--- a/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigUser.cs
+++ b/src/Discord.Addons.SimplePermissions.EFProvider/Models/ConfigUser.cs
@@ -15,7 +15,7 @@ namespace Discord.Addons.SimplePermissions
 
         /// <summary> </summary>
         //[Column(TypeName = "BIGINT")]
-        [NotMapped]
+        //[NotMapped]
         public ulong UserId
         {
             get => unchecked((ulong)_uid);

--- a/src/Discord.Addons.SimplePermissions/PermissionsService.cs
+++ b/src/Discord.Addons.SimplePermissions/PermissionsService.cs
@@ -342,21 +342,21 @@ namespace Discord.Addons.SimplePermissions
 
     public static class PermissionsExtensions
     {
-        ///// <summary> Add SimplePermissions to your <see cref="CommandService"/> using a <see cref="DiscordSocketClient"/>. </summary>
-        ///// <param name="client">The <see cref="DiscordSocketClient"/> instance.</param>
-        ///// <param name="configStore">The <see cref="IConfigStore{TConfig}"/> instance.</param>
-        ///// <param name="map">The <see cref="IDependencyMap"/> instance.</param>
-        ///// <param name="logAction">Optional: A delegate or method that will log messages.</param>
-        //public static Task UseSimplePermissions(
-        //    this CommandService cmdService,
-        //    DiscordSocketClient client,
-        //    IConfigStore<IPermissionConfig> configStore,
-        //    IServiceCollection map,
-        //    Func<LogMessage, Task> logAction = null)
-        //{
-        //    map.AddSingleton(new PermissionsService(configStore, cmdService, client, logAction ?? (msg => Task.CompletedTask)));
-        //    return cmdService.AddModuleAsync<PermissionsModule>();
-        //}
+        /// <summary> Add SimplePermissions to your <see cref="CommandService"/> using a <see cref="DiscordSocketClient"/>. </summary>
+        /// <param name="client">The <see cref="DiscordSocketClient"/> instance.</param>
+        /// <param name="configStore">The <see cref="IConfigStore{TConfig}"/> instance.</param>
+        /// <param name="map">The <see cref="IDependencyMap"/> instance.</param>
+        /// <param name="logAction">Optional: A delegate or method that will log messages.</param>
+        public static Task UseSimplePermissions(
+            this CommandService cmdService,
+            DiscordSocketClient client,
+            IConfigStore<IPermissionConfig> configStore,
+            IServiceCollection map,
+            Func<LogMessage, Task> logAction = null)
+        {
+            map.AddSingleton(new PermissionsService(configStore, cmdService, client, logAction ?? (msg => Task.CompletedTask)));
+            return cmdService.AddModuleAsync<PermissionsModule>();
+        }
 
         ///// <summary> Add SimplePermissions to your <see cref="CommandService"/> using a <see cref="DiscordShardedClient"/>. </summary>
         ///// <param name="client">The <see cref="DiscordShardedClient"/> instance.</param>


### PR DESCRIPTION
removed the [Not Mapped] attribute from properites in EFCoreProvider to stop duplication of database entries,

Tested with [Not Mapped] removed have working against 2.0 beta of discord.net